### PR TITLE
Highlight logged-in music services

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,34 +43,64 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-function SpotifyLoginButton() {
+function SpotifyLoginButton({ loggedIn }: { loggedIn?: boolean }) {
   return (
     <button
       onClick={() => (window.location.href = `${API_BASE}/auth/login`)}
-      className="px-2 py-1 text-xs rounded-lg border border-zinc-700/80 bg-zinc-900/70"
+      className={`px-2 py-1 text-xs rounded-lg border bg-zinc-900/70 inline-flex items-center ${
+        loggedIn
+          ? "border-green-500 shadow-[0_0_6px_rgba(34,197,94,0.6)]"
+          : "border-zinc-700/80"
+      }`}
     >
+      {loggedIn && (
+        <span
+          className="mr-1 h-2 w-2 rounded-full bg-red-500 animate-pulse"
+          aria-hidden
+        />
+      )}
       Spotify
     </button>
   );
 }
 
-function AppleMusicLoginButton() {
+function AppleMusicLoginButton({ loggedIn }: { loggedIn?: boolean }) {
   return (
     <button
       onClick={() => (window.location.href = `${API_BASE}/auth/apple`)}
-      className="px-2 py-1 text-xs rounded-lg border border-zinc-700/80 bg-zinc-900/70"
+      className={`px-2 py-1 text-xs rounded-lg border bg-zinc-900/70 inline-flex items-center ${
+        loggedIn
+          ? "border-green-500 shadow-[0_0_6px_rgba(34,197,94,0.6)]"
+          : "border-zinc-700/80"
+      }`}
     >
+      {loggedIn && (
+        <span
+          className="mr-1 h-2 w-2 rounded-full bg-red-500 animate-pulse"
+          aria-hidden
+        />
+      )}
       Apple Music
     </button>
   );
 }
 
-function YouTubeMusicLoginButton() {
+function YouTubeMusicLoginButton({ loggedIn }: { loggedIn?: boolean }) {
   return (
     <button
       onClick={() => (window.location.href = `${API_BASE}/auth/youtube`)}
-      className="px-2 py-1 text-xs rounded-lg border border-zinc-700/80 bg-zinc-900/70"
+      className={`px-2 py-1 text-xs rounded-lg border bg-zinc-900/70 inline-flex items-center ${
+        loggedIn
+          ? "border-green-500 shadow-[0_0_6px_rgba(34,197,94,0.6)]"
+          : "border-zinc-700/80"
+      }`}
     >
+      {loggedIn && (
+        <span
+          className="mr-1 h-2 w-2 rounded-full bg-red-500 animate-pulse"
+          aria-hidden
+        />
+      )}
       YouTube Music
     </button>
   );
@@ -273,6 +303,46 @@ function RootApp() {
       doNotPlay: [],
     }
   );
+  type Service = "spotify" | "apple" | "youtube";
+  const [serviceLogins, setServiceLogins] = useState<Record<Service, boolean>>({
+    spotify: false,
+    apple: false,
+    youtube: false,
+  });
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await fetch(`${API_BASE}/api/auth/status`, {
+          credentials: "include",
+        });
+        if (r.ok) setServiceLogins((s) => ({ ...s, spotify: true }));
+      } catch {}
+    })();
+
+    const match = window.location.hash.match(/logged-in=([^&]+)/);
+    let svc = match ? match[1] : null;
+    if (svc) {
+      if (svc === "1") svc = "spotify";
+      setServiceLogins((s) => ({ ...s, [svc as Service]: true }));
+      try {
+        localStorage.setItem(`moodmix_login_${svc}`, "1");
+      } catch {}
+      history.replaceState(
+        null,
+        "",
+        window.location.pathname + window.location.search
+      );
+    } else {
+      for (const s of ["spotify", "apple", "youtube"] as const) {
+        try {
+          if (localStorage.getItem(`moodmix_login_${s}`) === "1") {
+            setServiceLogins((v) => ({ ...v, [s]: true }));
+          }
+        } catch {}
+      }
+    }
+  }, []);
   useEffect(() => {
     const onReady = async () => {
       // Needs a logged-in Spotify cookie from /auth/callback
@@ -374,9 +444,9 @@ function RootApp() {
       <header className="relative px-4 py-5 sm:py-7 lg:py-8 border-b border-zinc-800/70 backdrop-blur-sm bg-zinc-950/40 grid grid-cols-1 sm:grid-cols-[1fr_auto_1fr] items-center gap-2">
         {/* LEFT: music service logins */}
         <div className="hidden sm:flex items-center gap-2">
-          <SpotifyLoginButton />
-          <AppleMusicLoginButton />
-          <YouTubeMusicLoginButton />
+          <SpotifyLoginButton loggedIn={serviceLogins.spotify} />
+          <AppleMusicLoginButton loggedIn={serviceLogins.apple} />
+          <YouTubeMusicLoginButton loggedIn={serviceLogins.youtube} />
         </div>
 
         {/* CENTER: Logo (stays centered) */}
@@ -422,9 +492,9 @@ function RootApp() {
 
         {/* MOBILE: music service logins pinned to top-left */}
         <div className="sm:hidden absolute left-3 top-3 flex gap-2">
-          <SpotifyLoginButton />
-          <AppleMusicLoginButton />
-          <YouTubeMusicLoginButton />
+          <SpotifyLoginButton loggedIn={serviceLogins.spotify} />
+          <AppleMusicLoginButton loggedIn={serviceLogins.apple} />
+          <YouTubeMusicLoginButton loggedIn={serviceLogins.youtube} />
         </div>
 
         {/* MOBILE: ONLY the sign button pinned to top-right */}


### PR DESCRIPTION
## Summary
- show logged-in status for Spotify, Apple Music and YouTube Music buttons
- add hook tracking service logins and style active providers with green glow and pulsing red dot

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0a01d635483219a3a3b1f203f2148