### PR TITLE
feat: infer API base url for codesandbox

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,8 +7,8 @@ import cookieParser from "cookie-parser";
 
 const SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
 const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
-const REDIRECT_URI = process.env.SPOTIFY_REDIRECT_URI; // e.g. https://dtrlrc-3002.csb.app/auth/callback
-const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN; // e.g. https://dtrlrc-5173.csb.app
+const REDIRECT_URI = process.env.SPOTIFY_REDIRECT_URI; // e.g. https://your-sandbox-id-3002.csb.app/auth/callback
+const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN; // e.g. https://your-sandbox-id-5173.csb.app
 
 // super-light in-memory sessions (fine for sandbox/testing)
 const sessions = new Map();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,11 @@ import React, {
 import { Card, CardContent, CardHeader, CardTitle } from "./components/ui/card";
 import { Button } from "./components/ui/button";
 
-const API_BASE = "https://dtrlrc-3002.csb.app";
+const API_BASE =
+  import.meta.env.VITE_API_BASE ??
+  (window.location.origin.includes("csb.app")
+    ? window.location.origin.replace(/-\d+\.csb\.app$/, "-3002.csb.app")
+    : window.location.origin.replace(/:\d+$/, ":3002"));
 // TEMP: expose so you can see it in the console
 console.log("API_BASE =", API_BASE);
 (window as any).API_BASE = API_BASE;


### PR DESCRIPTION
## Summary
- derive API base URL from current origin for CodeSandbox and localhost
- clarify example CodeSandbox origins in server env var comments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0abd761708321834c3c4acca0efbd