### PR TITLE
Add offline mix fallback when server fails

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -414,7 +414,21 @@ function RootApp() {
       setCurrentMix(mix); // updates your "Now Playing" section
     } catch (e) {
       console.error(e);
-      alert("Could not build Spotify mix.");
+      try {
+        // Fallback to local recommender when server mixing fails
+        const fallback = recommendFromPrompt(
+          prompt,
+          profile,
+          {
+            targetSeconds: (Number(targetMinutes) || 30) * 60,
+            instrumentalOnly,
+          }
+        );
+        setCurrentMix(fallback);
+      } catch (err) {
+        console.error(err);
+        alert("Could not build Spotify mix.");
+      }
     } finally {
       setIsGenerating(false);
     }


### PR DESCRIPTION
## Summary
- use local `recommendFromPrompt` to build mix when API call errors

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a0adfc7eb48321a1b00ef8a4f82e97