### PR TITLE
Initialize Express app before route declarations

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,11 @@ import fetch from "node-fetch";
 import crypto from "crypto";
 import cookieParser from "cookie-parser";
 
+const app = express();
+app.use(cookieParser());
+app.use(cors());
+app.use(express.json());
+
 const SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
 const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
 const REDIRECT_URI = process.env.SPOTIFY_REDIRECT_URI; // e.g. https://your-sandbox-id-3002.csb.app/auth/callback
@@ -203,12 +208,6 @@ app.get("/api/spotify/token", requireAuth, async (req, res) => {
   const access = await getUserAccessToken(req.sid);
   res.json({ access_token: access });
 });
-// somewhere central
-
-const app = express();
-app.use(cookieParser());
-app.use(cors());
-app.use(express.json());
 // ---- quick diagnostics ----
 app.get("/_debug/env", (_req, res) => {
   res.json({


### PR DESCRIPTION
## Summary
- Move Express app creation to the top of `server/index.js`.
- Register cookie-parser, CORS, and JSON middleware immediately after app initialization.

## Testing
- `npm --prefix server start` *(fails: Cannot find package 'cookie-parser')*


------
https://chatgpt.com/codex/tasks/task_e_68a0b28b0ee08321824c4569cadfe9ae